### PR TITLE
feat(react-mui-hooks/use-datagrid): Renamed filterChanged prop to refreshTable

### DIFF
--- a/apps/docs/components/ExampleUseDataGrid.tsx
+++ b/apps/docs/components/ExampleUseDataGrid.tsx
@@ -46,7 +46,7 @@ export function ExampleUseDataGrid() {
     });
 
     useEffect(() => {
-        dataGrid.filterChanged();
+        dataGrid.refreshTable();
     }, []);
 
     return (

--- a/packages/react-mui-hooks/hooks/useDataGrid.tsx
+++ b/packages/react-mui-hooks/hooks/useDataGrid.tsx
@@ -327,7 +327,7 @@ export type UseDataGridProps = {
  */
 export type UseDataGridResponse = {
     props: ComponentPropsWithRef<typeof DataGridPro>,
-    filterChanged: (keepPage?: boolean) => void,
+    refreshTable: (keepPage?: boolean) => void,
     isSelectAll: boolean,
     setIsSelectAll: (value: boolean) => void,
     isAnySelected: boolean,
@@ -406,10 +406,11 @@ export function useDataGrid({
     }, [pageSize, sortModel, filterModel, onPage, loading]);
 
     /**
-     * Handles filter changed. This will go back to first page and request page.
-     * @param keepPage - If set to true, when filter is changed, page will remain selected; returns to first page if set to false.
+     * Handles the table refresh. This will go back to the first page and request a new one.
+     *
+     * @param keepPage - If set to true, when table is refreshed, page will remain selected; returns to first page if set to false.
      */
-    const handleFilterChanged = (keepPage = false) => {
+    const handleTableRefresh = (keepPage = false) => {
         if (!keepPage) setPageIndex(-1);
 
         handleLoadPage(keepPage ? pageIndex : -1, true);
@@ -727,7 +728,7 @@ export function useDataGrid({
             slotProps,
             keepNonExistentRowsSelected
         },
-        filterChanged: handleFilterChanged,
+        refreshTable: handleTableRefresh,
         isSelectAll: isAllItemsSelected,
         setIsSelectAll: setIsAllItemsSelected,
         isAnySelected: customSelectionModel.length > 0,

--- a/packages/react-mui-hooks/temp/react-mui-hooks.api.md
+++ b/packages/react-mui-hooks/temp/react-mui-hooks.api.md
@@ -74,7 +74,7 @@ export type UseDataGridProps = {
 // @public
 export type UseDataGridResponse = {
     props: ComponentPropsWithRef<typeof DataGridPro>;
-    filterChanged: (keepPage?: boolean) => void;
+    refreshTable: (keepPage?: boolean) => void;
     isSelectAll: boolean;
     setIsSelectAll: (value: boolean) => void;
     isAnySelected: boolean;


### PR DESCRIPTION
## Changed
+ Renamed `filterChanged` prop to `refreshTable` because that's what it actually does