### PR TITLE
fix: Trying the GH_TOKEN secret usage

### DIFF
--- a/.github/workflows/npm-publish-reusable.yml
+++ b/.github/workflows/npm-publish-reusable.yml
@@ -1,5 +1,8 @@
 name: Publish npm package
 
+env:
+  GH_TOKEN: ${{ secrets.GH_TOKEN }}
+
 on:
     workflow_call:
         inputs:
@@ -15,27 +18,41 @@ jobs:
     publish:
         name: Publish ${{ inputs.name }}
         runs-on: ubuntu-latest
+
         steps:
         # Ensuring that only one PR-environment-creation per branch will run at a time
         - name: Mutex setup
           uses: ben-z/gh-action-mutex@v1.0-alpha-7
           with:
             branch: "mutex/${{ github.event.workflow_run.head_branch }}-publish"
+
+        # Default the GK_TOKEN to GITHUB_TOKEN if not present
+        - name: Look for GH_TOKEN
+          if: env.GH_TOKEN == ''
+          env:
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          run: echo "GH_TOKEN=${GITHUB_TOKEN}" >> $GITHUB_ENV
+
         - uses: actions/checkout@v4
           with:
             ref: main
+            token: ${{ env.GH_TOKEN }}
+
         - name: Setup pnpm
           uses: pnpm/action-setup@v2.4.0
           with:
             version: 'latest'
+
         - uses: actions/setup-node@v4
           with:
             node-version: "18.x"
             cache: "pnpm"
+
         - name: Setup npmrc
           run: pnpm config set '//registry.npmjs.org/:_authToken' "${NPM_TOKEN}"
           env:
             NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
         - name: Changelog
           id: version-bump
           uses: Enterwell/ChangelogManager-GitHub-Action@v3
@@ -44,13 +61,16 @@ jobs:
             should-bump-version: true
             changes-location: ./packages/${{ inputs.name }}/changes
             path-to-project-file: ./packages/${{ inputs.name }}/package.json
+
         - name: Commit changelog changes
           uses: EndBug/add-and-commit@v9.1.3
           with:
             message: "[skip ci] [version-bump] Automated commit for version ${{ steps.version-bump.outputs.bumped-semantic-version }}"
+
         - run: pnpm i --frozen-lockfile --filter=${{ inputs.name }}...
         - run: pnpm build --filter=${{ inputs.name }}...
         - run: pnpm publish --access public --filter=${{ inputs.name }} --no-git-checks
+
         - name: Git tags update
           run: |
             git config user.name github-actions
@@ -61,6 +81,7 @@ jobs:
             git tag -f "${{ inputs.name }}/v${{ steps.version-bump.outputs.bumped-major-part }}.${{ steps.version-bump.outputs.bumped-minor-part }}" "${{ inputs.name }}/v${{ steps.version-bump.outputs.bumped-semantic-version }}"
   
             git push -f --tags
+
         - name: Create GitHub release
           run: gh release create "${{ inputs.name }}/v${{ steps.version-bump.outputs.bumped-semantic-version }}" -n "${{ steps.version-bump.outputs.new-changes }}"
           env:


### PR DESCRIPTION
## Changed
+ According to [Push to protected branch from GitHub actions](https://til.cazzulino.com/devops-ci-cd/push-to-protected-branch-from-github-actions) you could use a different token on checkout, and the `GH_TOKEN` is already provided in the GitHub CLI with higher-permissions?