### PR TITLE
feat: Automatically retargeting contribution PRs

### DIFF
--- a/.github/workflows/pr-retarget.yml
+++ b/.github/workflows/pr-retarget.yml
@@ -12,7 +12,8 @@ on:
 jobs:
   # Retarget to stage branch if PR is opened against main branch directly
   # Only allow targeting main if they are from stage and hotfix branches
-  retarget-prs:
+  retarget-pr:
+    name: Retarget PR
     if: github.base_ref == 'main' && github.head_ref != 'stage' && github.head_ref != 'hotfix'
     runs-on: ubuntu-latest
 

--- a/.github/workflows/pr-retarget.yml
+++ b/.github/workflows/pr-retarget.yml
@@ -1,4 +1,4 @@
-name: Retarget PRs
+name: Retarget PR
 
 # Triggering the workflow on PR events of interest
 on:

--- a/.github/workflows/pr-retarget.yml
+++ b/.github/workflows/pr-retarget.yml
@@ -1,0 +1,28 @@
+name: Retarget PRs
+
+# Triggering the workflow on PR events of interest
+on:
+  pull_request:
+    types:
+      - "opened"
+      - "synchronize"
+      - "reopened"
+      - "edited"
+
+jobs:
+  # Retarget to stage branch if PR is opened against main branch directly
+  # Only allow targeting main if they are from stage and hotfix branches
+  retarget-prs:
+    if: github.base_ref == 'main' && github.head_ref != 'stage' && github.head_ref != 'hotfix'
+    runs-on: ubuntu-latest
+
+    steps:
+      # Checkout
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # Change PR target
+      - name: Change PR target
+        run: gh pr edit ${{ github.event.number }} --base stage
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Added
+ `pr-retarget.yml` workflow file that will retarget all contribution PRs that are targeting `main` branch to the `stage` branch instead
   + only `stage` and `hotfix` branches can target `main`
   
Closes #291 